### PR TITLE
feat: add entities (User, Chat, Message), db schema and example properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ node_modules/
 build/
 dist/
 .env
+
+### Configuration File
+/backend/src/main/resources/application.properties

--- a/backend/src/main/java/io/manuel/chatto/model/Chat.java
+++ b/backend/src/main/java/io/manuel/chatto/model/Chat.java
@@ -1,0 +1,55 @@
+package io.manuel.chatto.model;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "chats")
+public class Chat {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(name = "name", length = 100)
+	private String name;
+	
+	@Column(name = "is_group", nullable = false)
+	private boolean isGroup = false;
+	
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+	
+	@ManyToMany
+	@JoinTable(
+		name = "chat_members",
+		joinColumns = @JoinColumn(name = "chat_id"),
+		inverseJoinColumns = @JoinColumn(name = "user_id")
+	)
+	private Set<User> members = new HashSet<User>();
+	
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/backend/src/main/java/io/manuel/chatto/model/Message.java
+++ b/backend/src/main/java/io/manuel/chatto/model/Message.java
@@ -1,0 +1,41 @@
+package io.manuel.chatto.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "messages")
+public class Message {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+	
+	@ManyToOne
+	@JoinColumn(name = "sender_id", nullable = false)
+	private User sender;
+	
+	@ManyToOne
+	@JoinColumn(name = "chat_id", nullable = false)
+	private Chat chat;
+	
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/backend/src/main/java/io/manuel/chatto/model/User.java
+++ b/backend/src/main/java/io/manuel/chatto/model/User.java
@@ -1,0 +1,50 @@
+package io.manuel.chatto.model;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Entity
+@Table(name = "users")
+public class User {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+	
+	@Column(name = "username", nullable = false, length = 50)
+	private String username;
+	
+	@Column(name = "email", nullable = false, unique = true, length = 100)
+	private String email;
+	
+	@Column(name = "password", nullable = false, length = 255)
+	private String password;
+	
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+	
+	// Callback for setting a date
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+	
+}

--- a/backend/src/main/resources/application-example.properties
+++ b/backend/src/main/resources/application-example.properties
@@ -3,7 +3,7 @@ spring.application.name=Chatto
 # MySQL Connection
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/chatto_db
-spring.datasource.username=root
-spring.datasource.password=passsworld
+spring.datasource.username=your_db_username
+spring.datasource.password=yuor_db_password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-spring.application.name=Chatto
-
-# MySQL Connection
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:mysql://localhost:3306/chatto_db
-spring.datasource.username=root
-spring.datasource.password=passsworld
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.jpa.show-sql=true

--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -1,0 +1,37 @@
+CREATE SCHEMA chatto_db;
+
+USE chatto_db;
+
+CREATE TABLE users (
+	id BIGINT PRIMARY KEY  AUTO_INCREMENT,
+    username VARCHAR(50) NOT NULL,
+    email VARCHAR(100) UNIQUE NOT NULL,
+    password VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE chats (
+	id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(100),
+    is_group BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE chat_members (
+	chat_id BIGINT,
+    user_id BIGINT,
+    joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (chat_id, user_id),
+    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE messages (
+	id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    sender_id BIGINT NOT NULL,
+	chat_id BIGINT NOT NULL,
+	FOREIGN KEY (sender_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
### Changes
- Added User, Chat, Message entities
- Added schema.sql with database structure
- Added application-example.properties
- Updated .gitignore to exclude sensitive configs

### Notes
This PR sets up the base model for Chatto.
