### PR TITLE
feat(websocket): implement realtime messaging with JWT authentication

### DIFF
--- a/backend/src/main/java/io/manuel/chatto/config/SecurityConfig.java
+++ b/backend/src/main/java/io/manuel/chatto/config/SecurityConfig.java
@@ -1,13 +1,17 @@
 package io.manuel.chatto.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import io.manuel.chatto.security.JwtAuthenticationFilter;
 
@@ -24,8 +28,9 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http.csrf(t -> t.disable())
+		.cors(cors -> {})
 		.authorizeHttpRequests(auth -> auth
-		    .requestMatchers("/auth/register", "/auth/login").permitAll()
+		    .requestMatchers("/auth/register", "/auth/login", "/test/**", "/ws/**").permitAll()
 		    .anyRequest().authenticated()
 		)
 		.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
@@ -36,5 +41,18 @@ public class SecurityConfig {
 	@Bean
 	public BCryptPasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+	
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of("http://localhost:8000"));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowCredentials(true);
+		
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/backend/src/main/java/io/manuel/chatto/config/WebSocketConfig.java
+++ b/backend/src/main/java/io/manuel/chatto/config/WebSocketConfig.java
@@ -1,0 +1,39 @@
+package io.manuel.chatto.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import io.manuel.chatto.security.AuthChannelInterceptor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+	
+	private final AuthChannelInterceptor authChannelInterceptor;
+	
+	public WebSocketConfig(AuthChannelInterceptor authChannelInterceptor) {
+		this.authChannelInterceptor = authChannelInterceptor;
+	}
+	
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/topic");
+		registry.setApplicationDestinationPrefixes("/app");
+	}
+	
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws")
+			.setAllowedOriginPatterns("http://localhost:8000")
+			.withSockJS();
+	}
+	
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(authChannelInterceptor);
+	}
+}

--- a/backend/src/main/java/io/manuel/chatto/controller/ChatSocketController.java
+++ b/backend/src/main/java/io/manuel/chatto/controller/ChatSocketController.java
@@ -1,0 +1,38 @@
+package io.manuel.chatto.controller;
+
+import java.security.Principal;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import io.manuel.chatto.dto.MessageRequest;
+import io.manuel.chatto.dto.MessageResponse;
+import io.manuel.chatto.service.MessageService;
+
+@Controller
+public class ChatSocketController {
+	
+	private final MessageService messageService;
+	private final SimpMessagingTemplate messagingTemplate;
+	
+	public ChatSocketController(
+			MessageService messageService, 
+			SimpMessagingTemplate messagingTemplate) {
+		this.messageService = messageService;
+		this.messagingTemplate = messagingTemplate;
+	}
+
+	@MessageMapping("/chat.send")
+	public void sendMessage(@Payload MessageRequest request, 
+							Principal principal) {
+		String email = principal.getName();
+
+		MessageResponse saved = 
+				messageService.sendMessage(request.chatId(), email, request.content());
+		
+		messagingTemplate.convertAndSend("/topic/chats" + saved.chatId(), saved);
+	}
+	
+}

--- a/backend/src/main/java/io/manuel/chatto/controller/MessageController.java
+++ b/backend/src/main/java/io/manuel/chatto/controller/MessageController.java
@@ -1,6 +1,5 @@
 package io.manuel.chatto.controller;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.manuel.chatto.dto.MessageRequest;
 import io.manuel.chatto.dto.MessageResponse;
-import io.manuel.chatto.model.User;
 import io.manuel.chatto.service.MessageService;
 import jakarta.validation.Valid;
 
@@ -32,10 +30,10 @@ public class MessageController {
 	@PostMapping
 	public ResponseEntity<MessageResponse> sendMessage(
 			@Valid @RequestBody MessageRequest request,
-			@AuthenticationPrincipal User sender
+			@AuthenticationPrincipal String email
 	){
 		MessageResponse response = 
-				messageService.sendMessage(request.chatId(), sender, request.content());
+				messageService.sendMessage(request.chatId(), email, request.content());
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 	
@@ -43,10 +41,10 @@ public class MessageController {
 	public ResponseEntity<Page<MessageResponse>> getMessages(
 		@PathVariable Long chatId,
 		Pageable pageable,
-		@AuthenticationPrincipal User requester
+		@AuthenticationPrincipal String email
 	){
 		Page<MessageResponse> messages = 
-				messageService.getMessages(chatId, pageable, requester);
+				messageService.getMessages(chatId, pageable, email);
 		return ResponseEntity.ok(messages);
 	}
 	

--- a/backend/src/main/java/io/manuel/chatto/controller/WebSocketTestController.java
+++ b/backend/src/main/java/io/manuel/chatto/controller/WebSocketTestController.java
@@ -1,0 +1,39 @@
+package io.manuel.chatto.controller;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.manuel.chatto.dto.MessageResponse;
+
+@RestController
+@RequestMapping("/test")
+public class WebSocketTestController {
+	
+	private final SimpMessagingTemplate messagingTemplate;
+	
+	public WebSocketTestController(SimpMessagingTemplate messagingTemplate) {
+		this.messagingTemplate = messagingTemplate;
+	}
+
+	@PostMapping("/publish")
+	public ResponseEntity<String> publishTestMessage() {
+		MessageResponse fakeMessage = new MessageResponse(
+				999L, 
+				123L, 
+				2L, 
+				"Tester", 
+				"Hello from REST test!", 
+				LocalDateTime.now()
+		);
+		
+		messagingTemplate.convertAndSend("/topic/chats" + fakeMessage.chatId(), fakeMessage);
+		
+		return ResponseEntity.ok("Test message published to /topic/chats" + fakeMessage.chatId());
+	}
+	
+}

--- a/backend/src/main/java/io/manuel/chatto/model/User.java
+++ b/backend/src/main/java/io/manuel/chatto/model/User.java
@@ -1,8 +1,6 @@
 package io.manuel.chatto.model;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/backend/src/main/java/io/manuel/chatto/security/AuthChannelInterceptor.java
+++ b/backend/src/main/java/io/manuel/chatto/security/AuthChannelInterceptor.java
@@ -1,0 +1,57 @@
+package io.manuel.chatto.security;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import io.manuel.chatto.model.User;
+import io.manuel.chatto.repository.UserRepository;
+
+@Component
+public class AuthChannelInterceptor implements ChannelInterceptor {
+	
+	private final JwtService jwtService;
+	private final UserRepository userRepo;
+	
+	public AuthChannelInterceptor(JwtService jwtService, UserRepository userRepo) {
+		this.jwtService = jwtService;
+		this.userRepo = userRepo;
+	}
+	
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = 
+				MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+		
+		if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+			String authHeader = accessor.getFirstNativeHeader("Authorization");
+			
+			if (authHeader != null && authHeader.startsWith("Bearer ")) {
+				String token = authHeader.substring(7);
+				
+				if (jwtService.validateToken(token)) {
+					String email = jwtService.extractEmail(token);
+					User user = userRepo.findByEmail(email).orElse(null);
+					
+					if (user != null) {
+						UsernamePasswordAuthenticationToken authentication = 
+								new UsernamePasswordAuthenticationToken(email, null, null);
+						
+						SecurityContextHolder.getContext().setAuthentication(authentication);
+						
+						accessor.setUser(authentication);
+					}
+				}
+			}
+		}
+		
+		return message;
+	}
+	
+}

--- a/backend/src/main/java/io/manuel/chatto/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/io/manuel/chatto/security/JwtAuthenticationFilter.java
@@ -49,11 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				
 				if (user != null) {
 					UsernamePasswordAuthenticationToken authToken = 
-							new UsernamePasswordAuthenticationToken(
-									user, // Principal 
-									null, // Credential
-									null  // Authorities (for the future when i got role)
-							);
+							new UsernamePasswordAuthenticationToken(email, null, null);
 					
 					authToken.setDetails(
 						new WebAuthenticationDetailsSource().buildDetails(request)


### PR DESCRIPTION
### This PR adds realtime messaging support to Chatto.

- STOMP over WebSocket endpoint (/ws) with SockJS fallback
- AuthChannelInterceptor validates CONNECT frames using JWT
- JwtAuthenticationFilter updated to use email as principal
- ChatSocketController handles /app/chat.send and broadcasts to /topic/chats/{id}
- MessageService persists messages and enforces membership validation
- SecurityConfig updated for WebSocket integration

Testing was done using a temporary HTML client + Python static server. 
This file is not included in the repo because a proper frontend
will be developed soon in a future branch.